### PR TITLE
build: bump opens pr

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,5 +53,8 @@ jobs:
       - name: bump-version
         run: uv run cz bump
 
-      - name: push-to-main
-        run: git push --follow-tags
+      - name: open-pull-request
+        run: |
+          git checkout -b bump-version
+          git push --follow-tags
+          gh pr create -B main -H bump-version


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify the CI workflow to create a pull request for version bumps instead of pushing directly to the main branch.