### PR TITLE
fix: gh pr create fill

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: install-dependencies
-        run: uv sync --group release
+        run: uv sync --group bump
 
       - name: run-tests
         run: |
@@ -58,4 +58,4 @@ jobs:
         run: |
           git checkout -b bump-version
           git push --set-upstream origin bump-version --follow-tags
-          gh pr create -B main -H bump-version
+          gh pr create --base main --head bump-version --fill

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ test = [
     "pytest>=8.3.3",
     "pytest-cov>=6.0.0",
 ]
-release = [
+bump = [
     {include-group = "test"},
     "commitizen>=3.30.1",
     "genbadge[coverage,tests]>=1.1.1",


### PR DESCRIPTION
## Summary by Sourcery

Fix the GitHub Actions workflow by correcting the 'gh pr create' command and renaming the dependency group from 'release' to 'bump'.

Bug Fixes:
- Correct the 'gh pr create' command in the GitHub Actions workflow to use the '--fill' option.

Enhancements:
- Rename the dependency group from 'release' to 'bump' in the pyproject.toml and GitHub Actions workflow.

CI:
- Update the GitHub Actions workflow to use the 'bump' group for installing dependencies instead of 'release'.
- Modify the GitHub Actions workflow to use '--base' and '--head' options in the 'gh pr create' command.