### PR TITLE
fix: pr permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,5 +57,5 @@ jobs:
       - name: open-pull-request
         run: |
           git checkout -b bump-version
-          git push --set-upstream origin bump-version --follow-tags
+          git push --follow-tags --force --set-upstream origin bump-version
           gh pr create --base main --head bump-version --fill

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify the GitHub Actions workflow to force push the 'bump-version' branch when creating a pull request.