### PR TITLE
fix: various cd fixes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   BUMP_USERNAME: Mr Bump
-  BUMP_EMAIL: bump@users.noreply.github.com
+  BUMP_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
   COVERAGE_BADGE: reports/coverage/badge.svg
   COVERAGE_RESULTS: reports/coverage/results.xml
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -13,7 +13,7 @@ env:
   TESTS_RESULTS: reports/tests/results.xml
   
 jobs:
-  cd:
+  bump:
     name: bump
     runs-on: ubuntu-latest
     permissions:
@@ -35,7 +35,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: install-dependencies
-        run: uv sync --group bump
+        run: uv sync --frozen --group bump
 
       - name: run-tests
         run: |
@@ -53,7 +53,7 @@ jobs:
           git config user.email "$BUMP_EMAIL"
 
       - name: bump-version
-        run: uv run cz bump
+        run: uv run cz bump --annotated-tag --yes
 
       - name: open-pull-request
         run: |

--- a/TODO.md
+++ b/TODO.md
@@ -3,13 +3,11 @@
 These are all just ideas, nothing is guaranteed to be added.
 
 ## CI/CD
-- Semver
 - Pre-commit
-- Badge updates
+- Allow bump PR to trigger CI
 
 ## Documentation
 - Contributing
 - GitHub Pages
-
-## Tests
-- Coveralls
+    - Publish test results
+    - Publish documentation

--- a/uv.lock
+++ b/uv.lock
@@ -330,6 +330,12 @@ version = "0.0.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]
+bump = [
+    { name = "commitizen" },
+    { name = "genbadge", extra = ["coverage", "tests"] },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
@@ -339,12 +345,6 @@ dev = [
 lint = [
     { name = "mypy" },
     { name = "ruff" },
-]
-release = [
-    { name = "commitizen" },
-    { name = "genbadge", extra = ["coverage", "tests"] },
-    { name = "pytest" },
-    { name = "pytest-cov" },
 ]
 test = [
     { name = "pytest" },
@@ -354,6 +354,12 @@ test = [
 [package.metadata]
 
 [package.metadata.requires-dev]
+bump = [
+    { name = "commitizen", specifier = ">=3.30.1" },
+    { name = "genbadge", extras = ["coverage", "tests"], specifier = ">=1.1.1" },
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+]
 dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pytest", specifier = ">=8.3.3" },
@@ -363,12 +369,6 @@ dev = [
 lint = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "ruff", specifier = ">=0.7.3" },
-]
-release = [
-    { name = "commitizen", specifier = ">=3.30.1" },
-    { name = "genbadge", extras = ["coverage", "tests"], specifier = ">=1.1.1" },
-    { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 test = [
     { name = "pytest", specifier = ">=8.3.3" },


### PR DESCRIPTION
- Change bump email to GitHub bot
- Freeze uv lock file
- Change version tag to annotated tag
- Rename bump job

## Summary by Sourcery

Implement various fixes and enhancements to the continuous deployment workflow, including updating the bump email, renaming the job, freezing the uv lock file, and using annotated tags for versioning.

Bug Fixes:
- Fix the bump email to use the GitHub bot email address.

Enhancements:
- Rename the 'cd' job to 'bump' in the GitHub Actions workflow.
- Change the version tag to an annotated tag in the bump-version step.
- Freeze the uv lock file during dependency installation.

CI:
- Update the GitHub Actions workflow to reflect changes in job naming and email configuration.