### PR TITLE
build: trigger ci on bump pr

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,5 +58,16 @@ jobs:
       - name: open-pull-request
         run: |
           git checkout -b bump-version
-          git push --follow-tags --force --set-upstream origin bump-version
+          git push --follow-tags --set-upstream origin bump-version
           gh pr create --base main --head bump-version --fill
+
+      - name: trigger-ci  # Need to trigger CI using repository dispatch because workflows using the GITHUB_TOKEN cannot trigger other workflows.
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              ref: 'bump-version',
+            })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: ci
 
 on: 
   pull_request:
-  repository_dispatch: [ci_trigger]
+  repository_dispatch:
+    types: [ci_trigger]
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: ci
 
 on: 
-  pull_request
+  pull_request:
+  repository_dispatch: [ci_trigger]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A template for Python projects.
 [![mypy: checked](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 ![Tests Status](./reports/tests/badge.svg?dummy=8484744)
 ![Coverage Status](./reports/coverage/badge.svg?dummy=8484744)
-[![ci](https://github.com/Willlumm/python-template/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Willlumm/python-template/actions/workflows/ci.yml)
+[![ci](https://github.com/Willlumm/python-template/actions/workflows/ci.yml/badge.svg)](https://github.com/Willlumm/python-template/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Installation

--- a/TODO.md
+++ b/TODO.md
@@ -5,9 +5,20 @@ These are all just ideas, nothing is guaranteed to be added.
 ## CI/CD
 - Pre-commit
 - Allow bump PR to trigger CI
+- Format coverage badge
+- Create release
 
 ## Documentation
 - Contributing
 - GitHub Pages
     - Publish test results
     - Publish documentation
+
+## Tests
+- Coveralls
+
+## Code
+- Full Sourcery review
+- Docstrings
+
+- Professionalize profile


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a repository dispatch event to the CI workflow to allow triggering from other workflows.