### PR TITLE
fix: dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: ci
 
-on: 
-  pull_request:
-  repository_dispatch:
-    types: [ci_trigger]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Simplify the CI workflow trigger configuration by replacing 'repository_dispatch' with 'workflow_dispatch'.