### PR TITLE
add action permission

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,7 @@ jobs:
     name: bump
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add 'actions: write' permission to the GitHub Actions workflow in the cd.yml file.