### PR TITLE
build: trigger ci when auto-merge is enabled on pull request

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,6 @@
 name: cd
 
-on: 
-  workflow_dispatch
+on: workflow_dispatch
 
 env:
   BUMP_USERNAME: Mr Bump
@@ -17,7 +16,6 @@ jobs:
     name: bump
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -62,13 +60,3 @@ jobs:
           git push --follow-tags --set-upstream origin bump-version
           gh pr create --base main --head bump-version --fill
 
-      - name: trigger-ci  # Need to trigger CI using repository dispatch because workflows using the GITHUB_TOKEN cannot trigger other workflows.
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'ci.yml',
-              ref: 'bump-version',
-            })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: ci
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    types:
+      - auto_merge_enabled  # allow bump PR CI to run when automerge enabled
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   lint:


### PR DESCRIPTION
- Workflows are not triggered by GitHub actions using the `GITHUB_TOKEN`, meaning that the CI checks do not run when a bump pull request is opened.
- As a workaround, `auto_merge_enabled` is added as a trigger to the CI workflow, allowing it to run when a user approves the bump pull request.
- Also removed an unsuccessful workaround where the CI checks were triggered via workflow dispatch.

## Summary by Sourcery

Update CI workflow to trigger on 'auto_merge_enabled' event and remove the previous workaround for triggering CI checks.

CI:
- Add 'auto_merge_enabled' as a trigger to the CI workflow to ensure CI checks run when a pull request is approved for auto-merge.
- Remove the unsuccessful workaround that attempted to trigger CI checks via workflow dispatch.