### PR TITLE
fix: deploy docs 2

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,6 @@ name: deploy-docs
 
 on:
   push:
-    branches: "main"
     tags: "[0-9]+.[0-9]+.[0-9]+"
 
 env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ bump = [
 ]
 docs = [
     {include-group = "test"},
-    "genbadge>=1.1.1",
     "mkdocs>=1.6.1",
+    "genbadge[coverage,tests]>=1.1.1",
 ]
 lint = [
     "mypy>=1.13.0",
@@ -31,11 +31,12 @@ dev = [
 ]
 
 [tool.commitizen]
+changelog_file = "docs/CHANGELOG.md"
 name = "cz_conventional_commits"
 tag_format = "$version"
-version_scheme = "semver2"
-version_provider = "pep621"
 update_changelog_on_bump = true
+version_provider = "pep621"
+version_scheme = "semver2"
 
 [tool.coverage.report]
 exclude_also = [
@@ -48,7 +49,7 @@ branch = true
 [tool.mypy]
 mypy_path = ["mypkg", "tests"]
 files = ["mypkg", "tests"]
-strict = "true"
+strict = true
 
 [tool.pytest.ini_options]
 addopts = "--cov=mypkg --cov-report=term-missing"
@@ -61,16 +62,15 @@ target-version = "py313"
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-    "COM812",   # Ignore absence of trailing commas, causes conflicts with formatter
-    "D",        # Ignore docstring rules
-    "ISC001",   # Ignore implicit string concatenation, causes conflicts with formatter
-    "T20"       # Ignore print rules
+    "COM812",           # Ignore absence of trailing commas, causes conflicts with formatter
+    "D",                # Ignore docstring rules
+    "ISC001",           # Ignore implicit string concatenation, causes conflicts with formatter
+    "T20"               # Ignore print rules
 ]
 fixable = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
-# Ignore asserts in tests
-"tests/*" = ["S101"]
+"tests/*" = ["S101"]    # Ignore asserts in tests
 
 [tool.uv]
-default-groups = [] # Only install project dependencies by default
+default-groups = []     # Only install project dependencies by default

--- a/uv.lock
+++ b/uv.lock
@@ -123,6 +123,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604 },
+]
+
+[[package]]
 name = "genbadge"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -135,6 +144,14 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/fe/aa88fb4cb7af92ad13663027c42c208e7cf99b49ee2b268f0a5ac52d26c6/genbadge-1.1.1.tar.gz", hash = "sha256:12cdaaacbc9e0ea3164bf580cfb87ec61ff17ae0728f09a7f0102f8ab3112f4c", size = 138463 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/46/ebb323793f294062e113847a46a114f30a28bea1dfcee453cfd72f10daf5/genbadge-1.1.1-py2.py3-none-any.whl", hash = "sha256:c8b67ccdad2867434cdc0be7c4bd3f6af6003c466d8ff5013b8b5842ca8730de", size = 100759 },
+]
+
+[package.optional-dependencies]
+coverage = [
+    { name = "defusedxml" },
+]
+tests = [
+    { name = "defusedxml" },
 ]
 
 [[package]]
@@ -450,7 +467,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
-    { name = "genbadge" },
+    { name = "genbadge", extra = ["coverage", "tests"] },
     { name = "mkdocs" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -476,7 +493,7 @@ dev = [
     { name = "ruff", specifier = ">=0.7.3" },
 ]
 docs = [
-    { name = "genbadge", specifier = ">=1.1.1" },
+    { name = "genbadge", extras = ["coverage", "tests"], specifier = ">=1.1.1" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
@@ -573,11 +590,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "75.3.0"
+version = "75.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/22/a438e0caa4576f8c383fa4d35f1cc01655a46c75be358960d815bfbb12bd/setuptools-75.3.0.tar.gz", hash = "sha256:fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686", size = 1351577 }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/db/722a42ffdc226e950c4757b3da7b56ff5c090bb265dccd707f7b8a3c6fee/setuptools-75.5.0.tar.gz", hash = "sha256:5c4ccb41111392671f02bb5f8436dfc5a9a7185e80500531b133f5775c4163ef", size = 1336032 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/12/282ee9bce8b58130cb762fbc9beabd531549952cac11fc56add11dcb7ea0/setuptools-75.3.0-py3-none-any.whl", hash = "sha256:f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd", size = 1251070 },
+    { url = "https://files.pythonhosted.org/packages/fe/df/88ccbee85aefbca071db004fdc8f8d2507d55d5a9dc27ebb93c92edb1bd8/setuptools-75.5.0-py3-none-any.whl", hash = "sha256:87cb777c3b96d638ca02031192d40390e0ad97737e27b6b4fa831bea86f2f829", size = 1222710 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Enhance the documentation build process by updating dependencies and adjust the CI workflow to deploy documentation on tag pushes. Configure commitizen to use a changelog file.

Enhancements:
- Update the documentation dependencies to include genbadge with coverage and tests extras.

CI:
- Modify the GitHub Actions workflow to trigger on tag pushes instead of branch pushes.

Chores:
- Add changelog file configuration to the commitizen tool settings.