### PR TITLE
fix: wrong dependencies in bump-version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -30,7 +30,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: install-dependencies
-        run: uv sync --frozen --group docs
+        run: uv sync --frozen --group bump
 
       - name: set-git-identity
         run: |


### PR DESCRIPTION
## Summary by Sourcery

Fix the dependency group in the 'bump-version' GitHub workflow to ensure the correct dependencies are installed.

Bug Fixes:
- Correct the dependency group used in the 'bump-version' workflow from 'docs' to 'bump'.

CI:
- Update the 'bump-version' GitHub workflow to use the correct dependency group.