### PR TITLE
fix: modify tag trigger

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,8 @@ name: deploy-docs
 
 on:
   push:
-    tags: "[0-9]+.[0-9]+.[0-9]+"
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 env:
   COVERAGE_BADGE: docs/reports/coverage/badge.svg


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify the tag trigger format in the deploy-docs workflow to use a list for specifying tags.