### PR TITLE
fix: tag condition

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: startsWith(github.event.ref, 'refs/tags/v')
+    if: github.ref_type == 'tag'
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,8 +2,8 @@ name: deploy-docs
 
 on:
   push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - main
 
 env:
   COVERAGE_BADGE: docs/reports/coverage/badge.svg
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 description = "A template for Python projects"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = [
-    "pytest-html>=4.1.1",
-]
+dependencies = []
 
 [dependency-groups]
 bump = [
@@ -16,6 +14,7 @@ docs = [
     {include-group = "test"},
     "mkdocs>=1.6.1",
     "genbadge[coverage,tests]>=1.1.1",
+    "pytest-html>=4.1.1",
 ]
 lint = [
     "mypy>=1.13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -450,11 +450,8 @@ wheels = [
 
 [[package]]
 name = "python-template"
-version = "0.0.0"
+version = "0.1.0"
 source = { virtual = "." }
-dependencies = [
-    { name = "pytest-html" },
-]
 
 [package.dev-dependencies]
 bump = [
@@ -471,6 +468,7 @@ docs = [
     { name = "mkdocs" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-html" },
 ]
 lint = [
     { name = "mypy" },
@@ -482,7 +480,6 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pytest-html", specifier = ">=4.1.1" }]
 
 [package.metadata.requires-dev]
 bump = [{ name = "commitizen", specifier = ">=3.30.1" }]
@@ -497,6 +494,7 @@ docs = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-html", specifier = ">=4.1.1" },
 ]
 lint = [
     { name = "mypy", specifier = ">=1.13.0" },


### PR DESCRIPTION
## Summary by Sourcery

Fix the GitHub Actions workflow to trigger on the 'main' branch and add a condition to run only on tag references. Adjust dependencies in pyproject.toml by moving 'pytest-html' to the 'docs' group.

Bug Fixes:
- Fix the tag condition in the GitHub Actions workflow to trigger on the 'main' branch instead of specific tags.

Enhancements:
- Add a condition to the GitHub Actions workflow to ensure it only runs when the reference type is a tag.

Build:
- Move 'pytest-html' dependency from the main dependencies list to the 'docs' dependency group in the pyproject.toml file.

CI:
- Update the GitHub Actions workflow to trigger on pushes to the 'main' branch instead of specific version tags.