### PR TITLE
fix: fetch depth 0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,6 +57,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: install-uv


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set fetch-depth to 0 in the GitHub Actions checkout step to ensure full repository history is available.